### PR TITLE
Set file permissions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.sandbox</groupId>
     <artifactId>githook-maven-plugin</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <packaging>maven-plugin</packaging>
     <name>Git Hook Plugin</name>
     <description>Maven plugin to configure and install local git hooks</description>

--- a/src/main/java/org/sandbox/GitHookInstallMojo.java
+++ b/src/main/java/org/sandbox/GitHookInstallMojo.java
@@ -9,6 +9,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 
 import java.io.IOException;
 import java.nio.file.*;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Map;
 
 import static java.nio.file.StandardOpenOption.*;
@@ -32,6 +33,7 @@ public final class GitHookInstallMojo extends AbstractMojo {
             String finalScript = SHEBANG + '\n' + hook.getValue();
             try {
                 Files.write(HOOK_DIR_PATH.resolve(hookName), finalScript.getBytes(), CREATE, TRUNCATE_EXISTING);
+                Files.setPosixFilePermissions(HOOK_DIR_PATH.resolve(hookName), PosixFilePermissions.fromString("rwxr-xr-x"));
             } catch (IOException e) {
                 throw new MojoExecutionException("could not write hook with name: " + hookName, e);
             }


### PR DESCRIPTION
set '-rwxr-xr-x' permissions on created hook

without this change installed hooks are not executable and therefore will not work without having to manually chmod them afterwards

bumped version to 1.0.1, to reflect change